### PR TITLE
Add optional Cheats directory

### DIFF
--- a/source/core.c
+++ b/source/core.c
@@ -29,6 +29,7 @@ unsigned audio_buffer_size_override;
 int state_slot;
 int resume_slot = -1;
 
+static char cheats_dir[MAX_PATH];
 static char config_dir[MAX_PATH];
 static char save_dir[MAX_PATH];
 static char system_dir[MAX_PATH];
@@ -292,6 +293,7 @@ static void set_directories(const char *core_name, const char *tag_name) {
 		mkdir(config_dir, 0755);
 	}
 
+	snprintf(cheats_dir, MAX_PATH, "%s/Cheats/%s/", sdcard_path, tag_name);
 	snprintf(save_dir, MAX_PATH, "%s/Saves/%s/", sdcard_path, tag_name);
 	snprintf(system_dir, MAX_PATH, "%s/Bios/%s", sdcard_path, tag_name);
 }
@@ -701,7 +703,7 @@ int core_load_content(struct content *content) {
 		goto finish;
 	}
 
-	content_based_name(content, cheats_path, sizeof(cheats_path), config_dir, "cheats/", ".cht");
+	content_based_name(content, cheats_path, sizeof(cheats_path), cheats_dir, NULL, ".cht");
 	if (cheats_path[0] != '\0') {
 		cheats = cheats_load(cheats_path);
 		core_apply_cheats(cheats);


### PR DESCRIPTION
This makes it possible to put cheats in (as an example) `/mnt/SDCARD/Cheats/GBC` rather than `/mnt/sdcard/.userdata/.picoarch-gambatte-GBC/cheats`. I'm open to other locations if you think they'd be better. It will show up in the advanced settings portion of the menu.

I think all that would need to be done to get this into MiniUI would be updating the submodule and creating a new build, but I'm not completely sure. I've got a few cores which seem to be failing to build so I can't test a full build, but it was still enough to build `./third-party/picoarch/output/picoarch` so I was able to test this on my Miyoo Mini.